### PR TITLE
Add Super-Linter as GitHub Action

### DIFF
--- a/.github/workflows/config/config.json
+++ b/.github/workflows/config/config.json
@@ -1,0 +1,8 @@
+{
+	"default": true,
+	"MD048": { "style": "backtick" },
+	"MD046": { "style": "fenced" },
+	"MD029": { "style": "one" },
+	"line-length": false,
+	"no-hard-tabs": false
+}

--- a/.github/workflows/rules/common/inlineTokenChildren.js
+++ b/.github/workflows/rules/common/inlineTokenChildren.js
@@ -1,0 +1,25 @@
+class InlineTokenChildren {
+    constructor(token) {
+        if (token.type === "inline") {
+            this.root = token;
+            this.column = -1;
+            this.lineNumber = token.map[0];
+        } else {
+            throw new TypeError("wrong argument token type");
+        }
+    }
+
+    *[Symbol.iterator]() {
+        for (let token of this.root.children) {
+            let { line, lineNumber } = token;
+            if (this.lineNumber !== lineNumber) {
+                this.column = -1;
+                this.lineNumber = lineNumber;
+            }
+            this.column = line.indexOf(token.content, this.column + 1);
+            yield { token, column: this.column + 1, lineNumber };
+        }
+    }
+}
+
+module.exports = { InlineTokenChildren };

--- a/.github/workflows/rules/common/wordPattern.js
+++ b/.github/workflows/rules/common/wordPattern.js
@@ -1,0 +1,40 @@
+class WordPattern {
+    constructor(pattern, parameters) {
+        const escapedDots = pattern.replace(/\\?\./g, "\\.");
+        this.pattern = parameters && parameters.hasOwnProperty('noWordBoundary') ? escapedDots : "\\b" + escapedDots + "\\b";
+        const modifiers = parameters && parameters.hasOwnProperty('caseSensitive') && parameters.caseSensitive ? "" : "i";
+        this.regex = new RegExp(this.pattern, modifiers);
+        this.suggestion = parameters && parameters.hasOwnProperty('suggestion') ? parameters.suggestion : pattern;
+        this.stringRegex = new RegExp("^" + escapedDots + "$", modifiers); // To match "Category" column words in changelogs, see case-sensitive.js
+        this.skipForUseCases = !!(parameters && parameters.hasOwnProperty('skipForUseCases'));
+    }
+
+    test(line) {
+        return new Match(line.match(this.regex));
+    }
+}
+
+class Match {
+    constructor(match) {
+        this.match = match;
+    }
+
+    range() {
+        if (this.match) {
+            let column = this.match.index + 1;
+            let length = this.match[0].length;
+            if (this.match[2]) {
+                column += this.match[1].length;
+                length -= this.match[1].length;
+            }
+            return [column, length];
+        }
+        return null;
+    }
+
+    toString() {
+        return this.match ? this.match.toString() : "null";
+    }
+}
+
+module.exports = { WordPattern };

--- a/.github/workflows/rules/md101.js
+++ b/.github/workflows/rules/md101.js
@@ -1,0 +1,142 @@
+const { InlineTokenChildren } = require("./common/inlineTokenChildren");
+const { WordPattern } = require("./common/wordPattern");
+
+const keywords = [
+    new WordPattern("curl"),
+    new WordPattern("wget"),
+    new WordPattern("crontab"),
+    new WordPattern("cron"),
+    new WordPattern("netcat"),
+    new WordPattern("ping"),
+    new WordPattern("traceroute"),
+    new WordPattern("sudo"),
+    new WordPattern("(?<!(system |ISRG ))root(?! ca)", { suggestion: "root" }),// match "root", but not "root CA", "MacOS System Root" and "ISRG Root X1"
+    new WordPattern("true"),
+    new WordPattern("false"),
+    new WordPattern("jps"),
+    new WordPattern("name=value"),
+    new WordPattern("key=value"),
+    new WordPattern("time:value"),
+    new WordPattern("atsd.log"),
+    new WordPattern("start.log"),
+    new WordPattern("logback.xml"),
+    new WordPattern("graphite.conf"),
+    new WordPattern("command_malformed.log"),
+    new WordPattern("stdout"),
+    new WordPattern("stdin"),
+    new WordPattern("stderr"),
+    new WordPattern("SIGHUP"),
+    new WordPattern("SIGINT"),
+    new WordPattern("SIGQUIT"),
+    new WordPattern("SIGILL"),
+    new WordPattern("SIGTRAP"),
+    new WordPattern("SIGABRT"),
+    new WordPattern("SIGBUS"),
+    new WordPattern("SIGFPE"),
+    new WordPattern("SIGKILL"),
+    new WordPattern("SIGUSR1"),
+    new WordPattern("SIGSEGV"),
+    new WordPattern("SIGUSR2"),
+    new WordPattern("SIGPIPE"),
+    new WordPattern("SIGALRM"),
+    new WordPattern("SIGTERM"),
+    new WordPattern("SIGSTKFLT"),
+    new WordPattern("SIGCHLD"),
+    new WordPattern("SIGCONT"),
+    new WordPattern("SIGSTOP"),
+    new WordPattern("SIGTSTP"),
+    new WordPattern("SIGTTIN"),
+    new WordPattern("SIGTTOU"),
+    new WordPattern("SIGURG"),
+    new WordPattern("SIGXCPU"),
+    new WordPattern("SIGXFSZ"),
+    new WordPattern("SIGVTALRM"),
+    new WordPattern("SIGPROF"),
+    new WordPattern("SIGWINCH"),
+    new WordPattern("SIGIO"),
+    new WordPattern("SIGPWR"),
+    new WordPattern("SIGSYS"),
+    new WordPattern("NaN"),
+    new WordPattern(".png", { noWordBoundary: true }),
+    new WordPattern(".xml", { noWordBoundary: true }),
+    new WordPattern(".svg", { noWordBoundary: true }),
+    new WordPattern(".jar", { noWordBoundary: true }),
+    new WordPattern(".gz", { noWordBoundary: true }),
+    new WordPattern(".tar.gz", { noWordBoundary: true }),
+    new WordPattern(".bz2", { noWordBoundary: true }),
+    new WordPattern(".tar.bz2", { noWordBoundary: true }),
+    new WordPattern(".zip", { noWordBoundary: true }),
+    new WordPattern(".txt", { noWordBoundary: true }),
+    new WordPattern(".tex", { noWordBoundary: true }),
+    new WordPattern(".yaml", { noWordBoundary: true }),
+    new WordPattern(".csv", { noWordBoundary: true }),
+    new WordPattern(".json", { noWordBoundary: true }),
+    new WordPattern(".pdf", { noWordBoundary: true }),
+    new WordPattern(".html", { noWordBoundary: true })
+    new WordPattern(".c", { noWordBoundary: true })
+    new WordPattern(".cpp", { noWordBoundary: true })
+    new WordPattern(".h", { noWordBoundary: true })
+    new WordPattern(".hpp", { noWordBoundary: true })
+    new WordPattern(".py", { noWordBoundary: true })
+    new WordPattern(".rs", { noWordBoundary: true })
+    new WordPattern(".d", { noWordBoundary: true })
+    new WordPattern(".go", { noWordBoundary: true })
+    new WordPattern(".js", { noWordBoundary: true })
+    new WordPattern(".java", { noWordBoundary: true })
+    new WordPattern(".go", { noWordBoundary: true })
+    new WordPattern(".php", { noWordBoundary: true })
+    new WordPattern(".pl", { noWordBoundary: true })
+    new WordPattern(".rb", { noWordBoundary: true })
+    new WordPattern(".o", { noWordBoundary: true })
+    new WordPattern(".a", { noWordBoundary: true })
+    new WordPattern(".so", { noWordBoundary: true })
+    new WordPattern(".obj", { noWordBoundary: true })
+    new WordPattern(".lib", { noWordBoundary: true })
+    new WordPattern(".dll", { noWordBoundary: true })
+    new WordPattern(".dylib", { noWordBoundary: true })
+
+];
+
+module.exports = {
+    names: ["MD101", "backtick-keywords"],
+    description: "Keywords must be fenced and must be in appropriate case.",
+    tags: ["backtick", "code", "bash"],
+    "function": (params, onError) => {
+        var inHeading = false;
+        var inLink = false;
+        for (let token of params.tokens) {
+            switch (token.type) {
+                case "heading_open":
+                    inHeading = true; break;
+                case "heading_close":
+                    inHeading = false; break;
+                case "inline":
+                    let children = new InlineTokenChildren(token);
+                    for (let { token: child, column, lineNumber } of children) {
+                        let isText = child.type === "text";
+                        switch (child.type) {
+                            case "link_open":
+                                inLink = true; break;
+                            case "link_close":
+                                inLink = false; break;
+                        }
+                        for (let k of keywords) {
+                            let anyCaseMatch = child.content.match(k.regex);
+                            if (anyCaseMatch != null) {
+                                let match = anyCaseMatch[0];
+                                let correct = k.suggestion;
+                                if ((!inHeading && !inLink && isText) || // Bad not fenced
+                                    (match !== correct)) { // Right fencing, wrong case
+                                    onError({
+                                        lineNumber,
+                                        detail: `Expected \`${correct}\`. Actual ${match}.`,
+                                        range: [column + anyCaseMatch.index, match.length]
+                                    })
+                                }
+                            }
+                        }
+                    }
+            }
+        }
+    }
+};

--- a/.github/workflows/rules/md102.js
+++ b/.github/workflows/rules/md102.js
@@ -1,0 +1,59 @@
+const http_keywords = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "Content-Type",
+    "Content-Encoding",
+    "User-Agent",
+    "200 OK",
+    "401 Unauthorized",
+    "403 Forbidden",
+    "404 Not Found",
+    "API_DATA_READ",
+    "API_DATA_WRITE",
+    "API_META_READ",
+    "API_META_WRITE",
+    "USER",
+    "EDITOR",
+    "ENTITY_GROUP_ADMIN",
+    "ADMIN"
+];
+const keywordsRegex = new RegExp(http_keywords.map(word => "\\b" + word + "\\b").join("|"));
+
+const { InlineTokenChildren } = require("./common/inlineTokenChildren");
+
+module.exports = {
+    names: ["MD102", "backtick-http"],
+    description: "HTTP keywords must be fenced.",
+    tags: ["backtick", "HTTP", "HTTPS"],
+    "function": (params, onError) => {
+        var inHeading = false;
+        for (let token of params.tokens) {
+            switch (token.type) {
+                case "heading_open":
+                    inHeading = true; break;
+                case "heading_close":
+                    inHeading = false; break;
+                case "inline":
+                    if (!inHeading) {
+                        let children = new InlineTokenChildren(token);
+                        for (let { token: child, column, lineNumber } of children) {
+                            if (child.type === "text") {
+                                let exactCaseMatch = child.content.match(keywordsRegex);
+                                if (exactCaseMatch != null) {
+                                    let match = exactCaseMatch[0];
+                                    onError({
+                                        lineNumber,
+                                        detail: `Expected \`${match}\`. Actual ${match}.`,
+                                        range: [column + exactCaseMatch.index, match.length]
+                                    })
+                                }
+                            }
+                        }
+                    }
+            }
+        }
+    }
+};

--- a/.github/workflows/rules/md103.js
+++ b/.github/workflows/rules/md103.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = {
+  "names": [ "MD103", "inline triple backticks" ],
+  "description": "inline triple backticks",
+  "tags": [ "backticks" ],
+  "function": function rule(params, onError) {
+    for (const inline of params.tokens.filter(function filterToken(token) {
+      return token.type === "inline";
+    })) {
+        const index = inline.content.toLowerCase().indexOf("```");
+        if (index !== -1) {
+          onError({
+            "lineNumber": inline.lineNumber,
+            "context": inline.content.substr(index - 1, 4),
+            "detail": "Expected `. Actual ```"
+          });
+        }
+      }
+  }
+};

--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -1,0 +1,35 @@
+"use strict";
+
+module.exports = {
+  names: ["MD104", "one line per sentence"],
+  description: "one line (and only one line) per sentence",
+  tags: ["sentences"],
+  function: function rule(params, onError) {
+    for (const inline of params.tokens.filter(function filterToken(token) {
+      return token.type === "inline";
+    })) {
+      var actual_lines = inline.content.split("\n");
+      actual_lines.forEach((line, index, arr) => {
+		let outside = true;
+		let count = 0;
+		Array.from(line).forEach((char) => {
+			if ((char == "." || char == "?" || char == "!" || char == ";" || char == ":") && outside) {
+				count++;
+			}
+			if (char == "`") outside = !outside;
+			if (char == "[") outside = false;
+			if (char == "(") outside = false;
+			if (char == "]") outside = true;
+			if (char == ")") outside = true;
+		});
+        if (count > 1) {
+          onError({
+            lineNumber: inline.lineNumber + index,
+            detail:
+              "Expected one sentence per line. Multiple end of sentence punctuation signs found on one line!",
+          });
+        }
+      });
+    }
+  },
+};

--- a/.github/workflows/rules/rules.js
+++ b/.github/workflows/rules/rules.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const rules = [
+	require("./md101.js"),
+	require("./md102.js"),
+	require("./md103.js"),
+	require("./md104.js"),
+];
+module.exports = rules;

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,27 @@
+name: Lint Code Base
+
+on: [push, pull_request]
+
+jobs:
+  superlinter:
+    name: Super Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          # Don't check already existent files
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_GITHUB_ACTIONS: false
+          LINTER_RULES_PATH: /.github/workflows/
+          MARKDOWN_CONFIG_FILE: config/config.json
+          MARKDOWN_CUSTOM_RULE_GLOBS: rules/rules.js
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use Super-Linter (https://github.com/github/super-linter) to validate files, including Markdown files. Markdown validation is configured in `config/config.json` and `rules/rules.js`.

Validation with Super-Linter is triggered for push actions and for pull requests.