### PR TITLE
Add empty entry for blog posts

### DIFF
--- a/website/docs/blog/_category_.json
+++ b/website/docs/blog/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Blog",
+  "position": 4
+}

--- a/website/docs/blog/intro.md
+++ b/website/docs/blog/intro.md
@@ -1,0 +1,4 @@
+# Introduction
+
+Here you will find written information about our activities.
+Get news about our latest content, meetings, and workshops, and read papers on education from us and our peers.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -60,6 +60,11 @@ const config = {
             position: 'left',
           },
           {
+            to: 'docs/blog/intro',
+            label: 'Blog',
+            position: 'left',
+          },
+          {
             href: 'https://github.com/open-education-hub/open-education-hub-site/',
             label: 'Repository',
             position: 'right',


### PR DESCRIPTION
It contains either short updates that are to be placed in the `news/` section or references to scientific articles under the `papers/` section.