### PR TITLE
events: Add description for M4 event

### DIFF
--- a/website/docs/events/m4.md
+++ b/website/docs/events/m4.md
@@ -1,0 +1,53 @@
+# Conference: Multiplier Event 4: Open Education
+
+At Open Education Hub, we have been working on creating a methodology, developing the support infrastructure, and populating digital content repositories, using the open source collaborative model.
+We want to capture feedback on these items, to raise awareness, and to encourage teachers and trainers to use them.
+
+So, on **Wednesday, September 13, 2023, 09:00-16:00 EEST**, we are hosting a multiplier event / conference to present our approach to developing and deploying digital educational materials as [Open Education Resources (OER)](https://en.wikipedia.org/wiki/Open_educational_resources).
+As part of the event, we are organizing practical workshops to get a hands-on experience of our work, and brainstorming meetings to get your input on important questions regarding the future of education in the digital age.
+Our goal is to extract best practices, guides and lessons learned, in order to build up the methods, approaches and infrastructure for the future of education, a future that will be tied to digitalization and technology.
+
+The event takes place in the [PRECIS Center](https://goo.gl/maps/cBXziUixXDXNfxko6), Faculty of Automatic Control and Computers, University POLITEHNICA of Bucharest.
+
+We will start with a conference style set of presentations, continue with practical workshops, have lunch and then do brainstorming sessions.
+We will have coffee & drinks freely available.
+
+If you are an educator with interest in improving the quality of educational materials and the process of using them to teach, evaluate and support learning, this is an event you want to be part of.
+
+If you plan to attend, please fill [this form](https://forms.gle/nLmRaEcYTbP7zyiC6).
+
+## Schedule
+
+* Date: Wednesday, September 13, 2023
+* Time: 09:00-16:00 EEST (Romania time)
+* Place: [PRECIS Center](https://goo.gl/maps/cBXziUixXDXNfxko6), Faculty of Automatic Control and Computers, University POLITEHNICA of Bucharest
+
+## Agenda
+
+* 09:00-09:15: Welcome
+* 09:15-10:45: Talks / Conference, room PR001
+  1. Open Education Hub: overview, goals, vision, values, results so far
+  1. Methodology for Open Education
+  1. Infrastructure for Open Education
+  1. Repository walkthrough
+* 10:45-11:15: Break: 1st floor foyer (PRECIS center)
+* 11:15-13:00: Workshops (bring a laptop): rooms PR002, PR003, PR103, PR106
+  1. Creating and deploying an Open Education Hub repository
+  1. Automating assignment evaluation with vmchecker
+  1. Adding linters and GitHub actions in your educational repository
+  1. Developing evaluation content with Open Education Hub (quizzes)
+* 13:00-14:00: Lunch: 1st floor foyer (PRECIS center)
+* 14:00-15:30: Brainstormings: rooms PR002, PR003, PR103, PR106
+  1. Attracting and engaging students during live activities (lecture, seminars)
+  1. Statistics and metrics for the teaching and learning processes
+  1. Using Open Education Hub methodology and infrastructure beyond Computer Science topics
+  1. Developing, maintaining and assessing assignments and projects as OERs
+* 15:30-16:00: Brainstorming conclusions and parting thoughts
+
+## Conclusion
+
+To be filled after the event
+
+### Takeaways
+
+To be filled after the event


### PR DESCRIPTION
Add description (goals, agenda, dates, links) for M4 event.

M4 is the final multipler event (ME): Closing event. It takes the form of a conference together with practical workshops and brainstorming sessions.