### PR TITLE
events: Update location for M4 event

### DIFF
--- a/website/docs/events/m4.md
+++ b/website/docs/events/m4.md
@@ -7,7 +7,7 @@ So, on **Wednesday, September 13, 2023, 09:00-16:00 EEST**, we are hosting a mul
 As part of the event, we are organizing practical workshops to get a hands-on experience of our work, and brainstorming meetings to get your input on important questions regarding the future of education in the digital age.
 Our goal is to extract best practices, guides and lessons learned, in order to build up the methods, approaches and infrastructure for the future of education, a future that will be tied to digitalization and technology.
 
-The event takes place in the [PRECIS Center](https://goo.gl/maps/cBXziUixXDXNfxko6), Faculty of Automatic Control and Computers, University POLITEHNICA of Bucharest.
+The event takes place in the [Central Library of University POLITEHNICA of Bucharest](https://goo.gl/maps/8NuZ3HXr7pKTToSp7).
 
 We will start with a conference style set of presentations, continue with practical workshops, have lunch and then do brainstorming sessions.
 We will have coffee & drinks freely available.
@@ -20,24 +20,24 @@ If you plan to attend, please fill [this form](https://forms.gle/nLmRaEcYTbP7zyi
 
 * Date: Wednesday, September 13, 2023
 * Time: 09:00-16:00 EEST (Romania time)
-* Place: [PRECIS Center](https://goo.gl/maps/cBXziUixXDXNfxko6), Faculty of Automatic Control and Computers, University POLITEHNICA of Bucharest
+* Place: [Central Library of University POLITEHNICA of Bucharest](https://goo.gl/maps/8NuZ3HXr7pKTToSp7), 2nd floor
 
 ## Agenda
 
 * 09:00-09:15: Welcome
-* 09:15-10:45: Talks / Conference, room PR001
+* 09:15-10:45: Talks / Conference, room 2.1, 2nd floor
   1. Open Education Hub: overview, goals, vision, values, results so far
   1. Methodology for Open Education
   1. Infrastructure for Open Education
   1. Repository walkthrough
-* 10:45-11:15: Break: 1st floor foyer (PRECIS center)
-* 11:15-13:00: Workshops (bring a laptop): rooms PR002, PR003, PR103, PR106
+* 10:45-11:15: Break: 2nd floor foyer
+* 11:15-13:00: Workshops (bring a laptop): rooms 2.1, 2.2, 2.3, 3.2
   1. Creating and deploying an Open Education Hub repository
   1. Automating assignment evaluation with vmchecker
   1. Adding linters and GitHub actions in your educational repository
   1. Developing evaluation content with Open Education Hub (quizzes)
-* 13:00-14:00: Lunch: 1st floor foyer (PRECIS center)
-* 14:00-15:30: Brainstormings: rooms PR002, PR003, PR103, PR106
+* 13:00-14:00: Lunch: 2nd floor foyer
+* 14:00-15:30: Brainstormings: rooms 2.1, 2.2, 2.3, 3.2
   1. Attracting and engaging students during live activities (lecture, seminars)
   1. Statistics and metrics for the teaching and learning processes
   1. Using Open Education Hub methodology and infrastructure beyond Computer Science topics


### PR DESCRIPTION
Event location has been moved from PRECIS Center to the UPB Central Library, due to a conflicting event in PRECIS.