### PR TITLE
events: Add skeleton slides for M4 event (conference)

### DIFF
--- a/website/docs/events/m4-slides/.gitignore
+++ b/website/docs/events/m4-slides/.gitignore
@@ -1,0 +1,2 @@
+/_site/
+/slides.md

--- a/website/docs/events/m4-slides/.slides/conclusion.md
+++ b/website/docs/events/m4-slides/.slides/conclusion.md
@@ -1,0 +1,28 @@
+---
+
+## Conclusion
+
+Owner: RăzvanD
+
+----
+
+### Results
+
+* methodology
+* infrastructure
+* repositories
+
+----
+
+### What Can I Do?
+
+* join [Discord](http://www.bit.ly/OpenEduHub)
+* take part in discussions, provide feedback, provide suggestions, provide use cases
+* use current and future content & infrastructure
+* contribute to content repositories: review, add new content
+* contribute to infrastructure repositories
+* port your own content to the OpenEdu methodology
+
+----
+
+We're Open (Education Hub)!

--- a/website/docs/events/m4-slides/.slides/infrastructure.md
+++ b/website/docs/events/m4-slides/.slides/infrastructure.md
@@ -1,0 +1,33 @@
+---
+
+## Infrastructure
+
+Owner: Sergiu
+
+----
+
+### (Open) Tools for Content Development and Curation
+
+TODO
+
+GitHub, Docker, Markdown, reveal-md, markdown-pp, GitHub Actions, super-linter & other linters, draw.io, ffmpeg, convert
+
+----
+
+### Content Publishing (openedu-builder)
+
+TODO
+
+also mention quiz work, even if in its early stages
+
+----
+
+### Automated Verification (vmchecker)
+
+TODO
+
+----
+
+### Digital Awards (SmileyCoins)
+
+TODO

--- a/website/docs/events/m4-slides/.slides/methodology.md
+++ b/website/docs/events/m4-slides/.slides/methodology.md
@@ -1,0 +1,25 @@
+---
+
+## Methodology
+
+Owner: RăzvanN
+
+probably follow structure in [the `methodology` repository](https://github.com/open-education-hub/methodology/), apart from infrastructure
+
+----
+
+### TODO
+
+TODO
+
+----
+
+### TODO
+
+TODO
+
+----
+
+### TODO
+
+TODO

--- a/website/docs/events/m4-slides/.slides/overview.md
+++ b/website/docs/events/m4-slides/.slides/overview.md
@@ -1,0 +1,23 @@
+---
+
+## Open Education Hub: Overview
+
+Owner: RazvanD
+
+----
+
+### Motivation and Goals
+
+TODO
+
+----
+
+### Results
+
+TODO
+
+----
+
+### Future Steps
+
+TODO

--- a/website/docs/events/m4-slides/.slides/repositories.md
+++ b/website/docs/events/m4-slides/.slides/repositories.md
@@ -1,0 +1,27 @@
+---
+
+## Repository Walkthrough
+
+----
+
+### Operating Systems
+
+Owner: Teo
+
+TODO
+
+----
+
+### Computing and Calculus for Applied Statistics
+
+Owner: Eggert
+
+TODO
+
+----
+
+### Security Summer School
+
+Owner: Gabi
+
+TODO

--- a/website/docs/events/m4-slides/Makefile
+++ b/website/docs/events/m4-slides/Makefile
@@ -1,0 +1,1 @@
+include ../../../src/common/makefile/slides.mk

--- a/website/docs/events/m4-slides/slides.mdpp
+++ b/website/docs/events/m4-slides/slides.mdpp
@@ -1,0 +1,20 @@
+---
+title: "Multiplier Event 4: Conference: Open Education"
+revealOptions:
+  background-color: 'aquamarine'
+  transition: 'none'
+  slideNumber: true
+  autoAnimateDuration: 0.0
+---
+
+# Open Education Hub
+
+!INCLUDE ".slides/overview.md"
+
+!INCLUDE ".slides/methodology.md"
+
+!INCLUDE ".slides/infrastructure.md"
+
+!INCLUDE ".slides/repositories.md"
+
+!INCLUDE ".slides/conclusion.md"


### PR DESCRIPTION
Add reveal-md + markdown-pp skeleton contents, similar to slides for other events. There are 5 sections with owners for each, marked in each `.md` file in the `.slides/` directory:

* overview: @razvand
* methodology: @RazvanN7
* infrastructure: @Sergiu121 (+ @VladNastase + @jokeswar)
* repositories: @teodutu, @eggertkarl, @gabrielmocanu
* conclusion: @razvand